### PR TITLE
修正了验证链上 validate 方法的返回值为最终值

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ declare namespace Acr {
     }
 
     class Chain {
-        validate(value: any): Promise<this>;
+        validate(value: any): Promise<any>;
         transform(fn: (value: any) => Promise<any> | any): Promise<any>;
         required(message?: string): this;
         default(value: any): this;

--- a/src/chain.js
+++ b/src/chain.js
@@ -135,7 +135,7 @@ class Chain {
             throw new ValidationError(result.detail);
         }
 
-        return this;
+        return this.value();
     }
 
     async value() {

--- a/test/acr.test.js
+++ b/test/acr.test.js
@@ -75,16 +75,16 @@ test('async validate error', async t => {
 });
 
 test('customize rule', async t => {
-    acr.type('test').define('foo', (value, { params }) => {
+    acr.type('test').define('equal', (value, { params }) => {
         return Promise.resolve(value === params[0] ? null : false);
     });
 
-    const chain = await acr
+    const value = await acr
         .test()
-        .foo('abel')
+        .equal('abel')
         .validate('abel');
 
-    t.true(chain instanceof Chain);
+    t.is(value, 'abel');
 });
 
 test('should be failed when return a string', async t => {

--- a/test/rules/number.test.js
+++ b/test/rules/number.test.js
@@ -1,6 +1,5 @@
 const test = require('ava');
 const Acr = require('../../src');
-const Chain = require('../../src/chain');
 
 let acr;
 test.beforeEach(() => {
@@ -8,11 +7,11 @@ test.beforeEach(() => {
 });
 
 test('equal', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .equal(12)
         .validate(12);
-    t.true(chain instanceof Chain);
+    t.is(value, 12);
 
     let promise = acr
         .number({ name: 'test' })
@@ -32,11 +31,11 @@ test('equal', async t => {
 });
 
 test('max', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .max(5)
         .validate(2);
-    t.true(chain instanceof Chain);
+    t.is(value, 2);
 
     let promise = acr
         .number('test')
@@ -56,11 +55,11 @@ test('max', async t => {
 });
 
 test('min', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .min(5)
         .validate(8);
-    t.true(chain instanceof Chain);
+    t.is(value, 8);
 
     let promise = acr
         .number('test')
@@ -80,11 +79,11 @@ test('min', async t => {
 });
 
 test('positive', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .positive()
         .validate(8);
-    t.true(chain instanceof Chain);
+    t.is(value, 8);
 
     let promise = acr
         .number('test')
@@ -104,11 +103,11 @@ test('positive', async t => {
 });
 
 test('negative', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .negative()
         .validate(-2);
-    t.true(chain instanceof Chain);
+    t.is(value, -2);
 
     let promise = acr
         .number('test')
@@ -128,11 +127,11 @@ test('negative', async t => {
 });
 
 test('integer', async t => {
-    const chain = await acr
+    const value = await acr
         .number()
         .integer()
         .validate(8);
-    t.true(chain instanceof Chain);
+    t.is(value, 8);
 
     let promise = acr
         .number('test')

--- a/test/rules/string.test.js
+++ b/test/rules/string.test.js
@@ -1,6 +1,5 @@
 const test = require('ava');
 const Acr = require('../../src');
-const Chain = require('../../src/chain');
 
 let acr;
 test.beforeEach(() => {
@@ -8,11 +7,11 @@ test.beforeEach(() => {
 });
 
 test('equal', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .equal('foo')
         .validate('foo');
-    t.true(chain instanceof Chain);
+    t.is(value, 'foo');
 
     let promise = acr
         .string({ name: 'test' })
@@ -32,11 +31,11 @@ test('equal', async t => {
 });
 
 test('max', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .max(5)
         .validate('foo');
-    t.true(chain instanceof Chain);
+    t.is(value, 'foo');
 
     let promise = acr
         .string('test')
@@ -56,11 +55,11 @@ test('max', async t => {
 });
 
 test('min', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .min(5)
         .validate('foobar');
-    t.true(chain instanceof Chain);
+    t.is(value, 'foobar');
 
     let promise = acr
         .string('test')
@@ -80,11 +79,11 @@ test('min', async t => {
 });
 
 test('length', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .length(5)
         .validate('fooba');
-    t.true(chain instanceof Chain);
+    t.is(value, 'fooba');
 
     let promise = acr
         .string('test')
@@ -97,18 +96,18 @@ test('length', async t => {
     promise = acr
         .string()
         .length(5, 'foobar')
-        .validate('foo');
+        .validate('foobar');
 
     error = await t.throws(promise);
     t.is(error.errors.message, 'foobar');
 });
 
 test('email', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .email()
         .validate('abel@seek.cx');
-    t.true(chain instanceof Chain);
+    t.is(value, 'abel@seek.cx');
 
     let promise = acr
         .string('test')
@@ -128,11 +127,11 @@ test('email', async t => {
 });
 
 test('regex', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .regex(/abel/)
         .validate('abel');
-    t.true(chain instanceof Chain);
+    t.is(value, 'abel');
 
     let promise = acr
         .string('test')
@@ -152,11 +151,11 @@ test('regex', async t => {
 });
 
 test('in', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .in(['foo', 'bar'])
         .validate('foo');
-    t.true(chain instanceof Chain);
+    t.is(value, 'foo');
 
     let promise = acr
         .string('test')
@@ -176,11 +175,11 @@ test('in', async t => {
 });
 
 test('objectId', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .objectId()
         .validate('5b2b5a1bcc6f21584075edc9');
-    t.true(chain instanceof Chain);
+    t.is(value, '5b2b5a1bcc6f21584075edc9');
 
     let promise = acr
         .string('test')
@@ -200,11 +199,11 @@ test('objectId', async t => {
 });
 
 test('base64', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .base64()
         .validate('MTIzNA==');
-    t.true(chain instanceof Chain);
+    t.is(value, 'MTIzNA==');
 
     let promise = acr
         .string('test')
@@ -232,11 +231,11 @@ test('base64', async t => {
 });
 
 test('url', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .url()
         .validate('https://seek.cx');
-    t.true(chain instanceof Chain);
+    t.is(value, 'https://seek.cx');
 
     let promise = acr
         .string('test')
@@ -256,11 +255,11 @@ test('url', async t => {
 });
 
 test('uuid', async t => {
-    const chain = await acr
+    const value = await acr
         .string()
         .uuid(4)
         .validate('b9a98908-436b-4481-9814-a0dd03ff1698');
-    t.true(chain instanceof Chain);
+    t.is(value, 'b9a98908-436b-4481-9814-a0dd03ff1698');
 
     let promise = acr
         .string('test')


### PR DESCRIPTION
之前验证链上的 validate 返回值为 Chain 对象，但 validate 一般是验证链上最后一个方法，返回 Chain 没有任何意义。修改之后返回当前值的最终结果（被 transform 处理）。

```js
const value = await acr.string()
  .equal('abel')
  .transform(value => {
    return 'im ' + value;
  }).validate('abel');

console.log(value); // im abel
```

- [x] 单元测试
- [x] d.ts 声明